### PR TITLE
detect npm command by lockfile

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -137,7 +137,7 @@ fn main() {
                 if task_runner.is_none() || task_runner.unwrap() == &manager_name {
                     if manager_name == "npm" {
                         let package_json = common::parse_package_json().unwrap();
-                        let package_command = common::get_package_command(&package_json);
+                        let package_command = common::get_npm_command(&package_json);
                         println!("{}", format!("  {}: {} - {}", package_command,
                                                managers::get_manager_file_name(&manager_name),
                                                managers::get_manager_web_url(&manager_name)).bold().blue());

--- a/src/managers/npm.rs
+++ b/src/managers/npm.rs
@@ -3,7 +3,7 @@ use std::process::Output;
 use error_stack::{report, Result};
 use which::which;
 use crate::command_utils::{run_command_line};
-use crate::common::{get_package_command, parse_package_json};
+use crate::common::{get_npm_command, parse_package_json};
 use crate::errors::KeeperError;
 
 pub fn is_available() -> bool {
@@ -14,7 +14,7 @@ pub fn is_available() -> bool {
 
 pub fn is_command_available() -> bool {
     let package_json = parse_package_json().unwrap();
-    let package_manager = get_package_command(&package_json);
+    let package_manager = get_npm_command(&package_json);
     which(package_manager).is_ok()
 }
 

--- a/src/runners/packagejson.rs
+++ b/src/runners/packagejson.rs
@@ -5,7 +5,7 @@ use crate::models::Task;
 use crate::command_utils::run_command;
 use crate::task;
 use which::which;
-use crate::common::{get_package_command, parse_package_json};
+use crate::common::{get_npm_command, parse_package_json};
 
 pub fn is_available() -> bool {
     std::env::current_dir()
@@ -15,7 +15,7 @@ pub fn is_available() -> bool {
 
 pub fn is_command_available() -> bool {
     let package_json = parse_package_json().unwrap();
-    let package_manager = get_package_command(&package_json);
+    let package_manager = get_npm_command(&package_json);
     which(package_manager).is_ok()
 }
 
@@ -35,7 +35,7 @@ pub fn list_tasks() -> Result<Vec<Task>, KeeperError> {
 
 pub fn run_task(task: &str, task_args: &[&str], global_args: &[&str], verbose: bool) -> Result<Output, KeeperError> {
     let package_json = parse_package_json()?;
-    let command_name = get_package_command(&package_json);
+    let command_name = get_npm_command(&package_json);
     let mut args = vec![];
     args.extend(global_args);
     args.push("run");


### PR DESCRIPTION
Many projects don't set `package-manager` in `package.json` - but having a lockfile clearly states which package manager is used