### PR TITLE
Fix nur URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Too many differences, I want to save my brain and keyboard, and you know MacBook
 * zed Tasks: https://zed.dev/docs/tasks
 * Rye: https://github.com/mitsuhiko/rye#scripts
 * argc: a Bash-based command runner https://github.com/sigoden/argc
-* nur: a task runner based on nu shell https://github.com/sigoden/argc
+* nur: a task runner based on nu shell https://github.com/ddanier/nur
 * cargo-xtask: https://github.com/linux-china/xtask-demo
 * go-xtask: https://github.com/linux-china/xtask-go-demo
 


### PR DESCRIPTION
First of all: I just discovered this project and I like the idea very much! Already install `task-keeper`. Let's see how this improves my CLI workflow.

Better yet: It already supports `nur`, the task runner I am currently writing. Very nice!  
(My initial thought was I should add support for `nur` and create a PR for this, I was very much positively surprised that `nur` was already supported)

After that I figured the URL to `nur` was wrong, possibly a simple copy&paste error.

This PR fixes just that 😉